### PR TITLE
Update pre-commit configuration to latest dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.15.17
     hooks:
       - id: ruff-check


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump the ruff-pre-commit hook revision from v0.12.0 to v0.15.17 in the pre-commit configuration.