### PR TITLE
Update pre-commit configuration to latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.17
+    rev: v0.15.18
     hooks:
       - id: ruff-check


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the pre-commit configuration to use ruff-pre-commit v0.15.18.