### PR TITLE
Fix WebUI group save crash and render/delivery kwargs wiring

### DIFF
--- a/command_handlers/manual.py
+++ b/command_handlers/manual.py
@@ -183,11 +183,15 @@ class ManualCommandMixin:
                 )
             except Exception as exc:
                 logger.warning(f"[NitterTweets] 搜索失败 query={query!r}: {exc}")
-                await event.send(event.plain_result(f"搜索失败：{exc}"))
+                await event.send(
+                    event.plain_result("搜索失败，请稍后重试或检查搜索镜像配置")
+                )
                 return
         except Exception as exc:
             logger.warning(f"[NitterTweets] 搜索失败 query={query!r}: {exc}")
-            await event.send(event.plain_result(f"搜索失败：{exc}"))
+            await event.send(
+                event.plain_result("搜索失败，请稍后重试或检查搜索镜像配置")
+            )
             return
 
         added = buf.add_tweets(list(fetched or []), instance=instance or "")

--- a/delivery/lark.py
+++ b/delivery/lark.py
@@ -248,6 +248,9 @@ class LarkDeliveryAdapter(DefaultDeliveryAdapter):
                 batch_summary,
                 tweet_start_index,
                 media_only,
+                omit_status_url=omit_status_url,
+                hide_original_when_translated=hide_original_when_translated,
+                link_style=link_style,
             )
 
         post_attempt = await send_lark_post(

--- a/docs/project/configuration.md
+++ b/docs/project/configuration.md
@@ -1,7 +1,5 @@
 # 配置说明
 
-（默认 true，去推文链接）与 # 配置说明
-
 配置真源是 `_conf_schema.json`。读取、迁移规则在 `config/compat.py`，分组解析规则在 `scheduler/config.py`。
 
 ## 分组

--- a/plugin_api/groups.py
+++ b/plugin_api/groups.py
@@ -149,15 +149,13 @@ class WebUIGroupEditor:
             data.get(
                 "omit_status_url",
                 raw_group.get("omit_status_url", True),
-            ),
-            True,
+            )
         )
         raw_group["hide_original_when_translated"] = self._bool(
             data.get(
                 "hide_original_when_translated",
                 raw_group.get("hide_original_when_translated", False),
-            ),
-            False,
+            )
         )
         if existing_type == "tag":
             try:

--- a/rendering/tweets.py
+++ b/rendering/tweets.py
@@ -612,7 +612,14 @@ class TweetMessageRenderer:
         return [
             Plain(
                 self.format_video_attachment_text(
-                    index, username, tweet, source, media_only=media_only
+                    index,
+                    username,
+                    tweet,
+                    source,
+                    media_only=media_only,
+                    omit_status_url=omit_status_url,
+                    hide_original_when_translated=hide_original_when_translated,
+                    link_style=link_style,
                 )
             ),
             Video.fromFileSystem(str(media.path)),
@@ -635,7 +642,14 @@ class TweetMessageRenderer:
         return [
             Plain(
                 self.format_image_attachment_text(
-                    index, username, tweet, source, media_only=media_only
+                    index,
+                    username,
+                    tweet,
+                    source,
+                    media_only=media_only,
+                    omit_status_url=omit_status_url,
+                    hide_original_when_translated=hide_original_when_translated,
+                    link_style=link_style,
                 )
             ),
             Image.fromFileSystem(str(media.path)),
@@ -764,7 +778,14 @@ class TweetMessageRenderer:
         return [
             self.raw_text(
                 self.format_video_attachment_text(
-                    index, username, tweet, source, media_only=media_only
+                    index,
+                    username,
+                    tweet,
+                    source,
+                    media_only=media_only,
+                    omit_status_url=omit_status_url,
+                    hide_original_when_translated=hide_original_when_translated,
+                    link_style=link_style,
                 )
             ),
             self.raw_media(media),
@@ -787,7 +808,14 @@ class TweetMessageRenderer:
         return [
             self.raw_text(
                 self.format_image_attachment_text(
-                    index, username, tweet, source, media_only=media_only
+                    index,
+                    username,
+                    tweet,
+                    source,
+                    media_only=media_only,
+                    omit_status_url=omit_status_url,
+                    hide_original_when_translated=hide_original_when_translated,
+                    link_style=link_style,
                 )
             ),
             self.raw_media(media),
@@ -1106,6 +1134,7 @@ class TweetMessageRenderer:
         safe_url = safe_url.replace("(", "%28").replace(")", "%29")
         return "[" + safe_label + "](" + safe_url + ")"
 
+    @staticmethod
     def format_video_attachment_text(
         index: int,
         username: str,

--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -241,6 +241,7 @@ class ScheduledCheckResult:
         if self.skipped_reason:
             reason_text = {
                 "no_watch_users": "未配置 watch_users",
+                "no_watch_queries": "未配置 watch_queries",
                 "no_push_targets": "未配置有效 push_targets",
                 "check_already_running": "已有一次检查正在运行",
                 "unknown_group": "未找到指定分组",

--- a/scheduler/runner.py
+++ b/scheduler/runner.py
@@ -471,6 +471,14 @@ class NitterTweetScheduler:
             account_total=1,
             tweet_index=1,
             tweet_total=1,
+            media_only=bool(getattr(group, "media_only_enabled", False)),
+            omit_status_url=bool(getattr(group, "omit_status_url", True)),
+            hide_original_when_translated=resolve_hide_original_when_translated(
+                self.config,
+                group_hide=bool(
+                    getattr(group, "hide_original_when_translated", False)
+                ),
+            ),
         )
         try:
             if translator_enabled:
@@ -502,6 +510,11 @@ class NitterTweetScheduler:
                         group_label=group_label,
                         batch_summary="",
                         tweet_start_index=1,
+                        media_only=batch.media_only,
+                        omit_status_url=batch.omit_status_url,
+                        hide_original_when_translated=(
+                            batch.hide_original_when_translated
+                        ),
                     )
                     if outcome.success:
                         await self._record_batch_push_history(
@@ -1765,7 +1778,13 @@ class NitterTweetScheduler:
 
     async def _cleanup_batch_media_many(self, batches: list[PendingTweetBatch]) -> None:
         for batch in batches:
-            await self._cleanup_batch_media(batch)
+            try:
+                await self._cleanup_batch_media(batch)
+            except Exception as exc:
+                logger.warning(
+                    "[NitterTweets] 批量媒体清理失败，继续清理其余批次: "
+                    f"user=@{batch.username}, error={exc}"
+                )
 
     async def _send_per_user_updates(
         self,


### PR DESCRIPTION
Remove erroneous second args to WebUIGroupEditor._bool, mark video attachment formatter staticmethod, forward omit/hide/link_style through attachment builders and Lark fallback, pass group flags on history replay, sanitize search errors, label no_watch_queries, and make batch media cleanup best-effort.