### PR TITLE
Enable user_html_fallback config with instance sharing and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ WebUI 不替代 AstrBot 设置页；Nitter 实例、媒体限制、AI provider�
 | --- | --- |
 | `instances` | 博主 RSS 列表；默认 `https://nitter.net`，可配多个。长期请改自建。 |
 | `search_instances` | 标签/搜索 HTML；默认 `tiekoetter.com`、`poast.org`、`kareem.one` 三镜像（3x 冗余 + 自动门禁）。**不要放 `nitter.net`**（它的搜索已不可用）。 |
-| `user_html_fallback` | RSS 失败时是否回退到 HTML（默认 `false`，不推荐）。开启会占用搜索资源，增加 429 风险。 |
+| `user_html_fallback` | RSS 失败时是否回退到 HTML（默认 `false`）。开启后会使用 `search_instances` 获取博主推文。⚠️ 占用搜索资源，增加 429 风险。推荐：配置多个 RSS 镜像。 |
 | `max_global_retries` | 全局重试轮数（默认 `2`）。所有实例失败后延迟重试，提升容错能力。 |
 
 **📖 详细说明：** [Nitter 实例配置指南](./docs/instances-guide.md) - RSS vs HTML 架构、默认配置、回退机制、容错策略

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -61,11 +61,10 @@
         "hint": "仅影响博主后台检查：开启后过滤订阅账号转发他人的推文；博主自己发布的引用或评论推文仍会保留。手动 /推文、/镜像测试 不受影响。老配置缺少该项时按开启处理。"
       },
       "user_html_fallback": {
-        "description": "博主 RSS 失败时尝试 HTML 用户页（高级）",
+        "description": "博主 RSS 失败时回退到 HTML",
         "type": "bool",
         "default": false,
-        "hint": "默认关闭。博主请用 instances 配置多个 RSS。开启后仍无独立 HTML 站列表，不会占用 search_instances，实际通常无法回退；留给兼容，不建议打开。",
-        "invisible": true
+        "hint": "默认关闭。RSS 全部失败时会尝试用 search_instances 的 HTML 用户页获取博主推文。⚠️ 开启后博主订阅会占用搜索实例资源，增加 429 限流风险，降低搜索成功率。推荐方案：在 instances 中配置多个 RSS 镜像。详见实例配置指南。"
       },
       "search_enabled": {
         "description": "启用 HTML 搜索",

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -110,7 +110,7 @@ AstrBot 设置界面已按“基础、媒体、AI 翻译、后台检查、推送
 | --- | --- |
 | `instances` | 博主 RSS 实例列表；默认 `https://nitter.net`，可配多个。建议自建。 |
 | `search_instances` | 标签/搜索 HTML；默认 `tiekoetter.com`、`poast.org`、`kareem.one` 三镜像（3x 冗余）。**不要放 `nitter.net`**（它的搜索已不可用）。 |
-| `user_html_fallback` | RSS 失败时是否回退到 HTML（默认 `false`，WebUI 不可见，不推荐开启）。开启会占用搜索资源，增加 429 风险。详见 [实例配置指南](./instances-guide.md)。 |
+| `user_html_fallback` | RSS 失败时是否回退到 HTML（默认 `false`）。开启后 RSS 全部失败时会尝试使用 `search_instances` 的 HTML 用户页获取博主推文。⚠️ 会占用搜索资源，增加 429 风险，降低搜索成功率。推荐方案：在 `instances` 中配置多个 RSS 镜像。详见 [实例配置指南](./instances-guide.md)。 |
 | `max_global_retries` | 全局重试轮数（默认 `2`）。所有实例失败后延迟重试（5s → 10s → 15s 渐进式），提升容错能力。 |
 | `retry_delay_base` | 全局重试基础延迟秒数（默认 `5.0`）。第 N 轮延迟 = N × retry_delay_base。 |
 | `retry_delay_on_cooldown` | 全部实例冷却时的重试延迟秒数（默认 `10.0`）。 |

--- a/docs/instances-guide.md
+++ b/docs/instances-guide.md
@@ -103,7 +103,7 @@
 
 ### 配置项
 
-**`user_html_fallback`**（默认 `false`，WebUI 不可见）
+**`user_html_fallback`**（默认 `false`，WebUI 可见）
 
 ### 行为说明
 
@@ -118,15 +118,15 @@
 5. ✅ 不会自动切换到 search_instances
 ```
 
-**回退行为（`user_html_fallback: true`，不推荐）：**
+**回退行为（`user_html_fallback: true`）：**
 ```
-1. 尝试所有 instances → 全部失败
-2. ⚠️ 回退到 search_instances
-3. 尝试 HTML /username 路径
+1. 尝试所有 instances（RSS）→ 全部失败
+2. ⚠️ 自动回退到 search_instances（HTML /username 路径）
+3. 尝试 HTML 搜索实例的用户页
 4. 成功则返回结果
 ```
 
-### 为什么不推荐开启回退？
+### 为什么默认关闭？
 
 | 问题 | 影响 |
 |------|------|
@@ -135,7 +135,7 @@
 | **降低搜索成功率** | 博主回退占用可能导致真正的搜索失败 |
 | **错误信息混淆** | 难以区分是 RSS 问题还是搜索问题 |
 
-### 何时可以临时开启？
+### 何时可以开启？
 
 **仅在以下情况下考虑：**
 1. ✅ 你的 `instances` 完全不可用（所有 RSS 镜像都挂了）
@@ -143,10 +143,15 @@
 3. ✅ 你的 `search_instances` 有足够的配额（自建或低频使用）
 4. ✅ 你理解这只是临时应急方案
 
-**开启后尽快：**
-1. 修复或更换 `instances` 中的 RSS 镜像
-2. 关闭 `user_html_fallback`
-3. 监控 `search_instances` 的 429 限流情况
+**推荐长期方案：**
+1. 在 `instances` 中配置多个 RSS 镜像（推荐 2-3 个）
+2. 或者自建 Nitter 实例
+3. 定期检查实例健康度
+
+**开启后需要监控：**
+1. `search_instances` 的 429 限流情况
+2. 搜索命令的成功率变化
+3. 博主订阅的响应延迟
 
 ---
 

--- a/media_support/html_backend/service.py
+++ b/media_support/html_backend/service.py
@@ -90,11 +90,15 @@ class HtmlNitterService:
             session_dir=Path(session_dir) if session_dir else None,
             log=self.log,
         )
-        # Blogger HTML pool intentionally empty: no dedicated config list and no
-        # borrowing search_instances (avoids starving tag search).
+        # Blogger HTML pool: when user_html_fallback is enabled, share
+        # search_instances for RSS blogger fallback. Default off to avoid
+        # starving tag search.
+        blogger_instances = (
+            list(self.config.search_instances) if self.config.user_html_fallback else []
+        )
         self.blogger_html = HtmlNitterPool(
             PoolConfig(
-                instances=[],
+                instances=blogger_instances,
                 proxy=self.config.proxy,
                 timeout=self.config.html_timeout,
                 session_dir=session_dir,
@@ -130,9 +134,9 @@ class HtmlNitterService:
         *,
         instance: str | None = None,
     ) -> tuple[str, list[TweetItem]]:
-        # The dedicated blogger HTML pool was removed from the shipped
-        # configuration.  A stale ``user_html_fallback=true`` must degrade to
-        # an ordinary empty fallback rather than raising from an empty pool.
+        # When user_html_fallback is enabled, blogger_html shares
+        # search_instances. When disabled (default), pool is empty and we
+        # return early to avoid triggering an empty-pool error.
         if not self.blogger_html.instances and not instance:
             return "", []
         return self.blogger_html.fetch_user(username, limit, instance=instance)

--- a/test/verify_instances.py
+++ b/test/verify_instances.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""验证插件实例配置：RSS vs HTML 搜索分离"""
+
+import sys
+from pathlib import Path
+
+# 添加项目根目录到路径
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# ruff: noqa: E402
+from shared.utils import DEFAULT_INSTANCES
+from media_support.html_backend.service import (
+    DEFAULT_SEARCH_INSTANCES,
+    DEFAULT_TIEKOETTER,
+    DEFAULT_POAST,
+    DEFAULT_KAREEM,
+)
+
+
+def main():
+    import io
+
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+    print("=" * 60)
+    print("插件实例配置验证")
+    print("=" * 60)
+
+    print("\n✅ RSS 实例（用户订阅专用）")
+    print("=" * 40)
+    for i, instance in enumerate(DEFAULT_INSTANCES, 1):
+        print(f"  {i}. {instance}")
+    print("\n  用途: 用户时间线 RSS 订阅")
+    print("  特点: nitter.net RSS 稳定，HTML 路径不可用")
+
+    print("\n✅ HTML 搜索实例（标签搜索专用）")
+    print("=" * 40)
+    for i, instance in enumerate(DEFAULT_SEARCH_INSTANCES, 1):
+        gate = {
+            DEFAULT_TIEKOETTER: "Anubis PoW",
+            DEFAULT_POAST: "Poast SHA1",
+            DEFAULT_KAREEM: "轻量门禁",
+        }.get(instance, "未知")
+        print(f"  {i}. {instance}")
+        print(f"     门禁: {gate}")
+    print("\n  用途: 标签搜索（#NASA）")
+    print("  特点: CF 实验验证，支持自动门禁解算")
+
+    print("\n✅ 实例分离策略")
+    print("=" * 40)
+    print("  • nitter.net → 仅 RSS（搜索返回 200 空 body）")
+    print("  • tiekoetter/poast/kareem → 仅搜索（RSS 403）")
+    print("  • 健康度评分 + 自动轮换")
+    print("  • 429 冷却保护")
+
+    print("\n✅ 验证结果")
+    print("=" * 40)
+
+    # 验证分离
+    rss_set = set(DEFAULT_INSTANCES)
+    search_set = set(DEFAULT_SEARCH_INSTANCES)
+    overlap = rss_set & search_set
+
+    if not overlap:
+        print("  ✓ RSS 和搜索实例完全分离")
+    else:
+        print(f"  ✗ 发现重叠实例: {overlap}")
+        return 1
+
+    # 验证搜索实例完整
+    expected = {DEFAULT_TIEKOETTER, DEFAULT_POAST, DEFAULT_KAREEM}
+    if search_set == expected:
+        print("  ✓ 搜索实例包含所有 CF 验证的镜像")
+    else:
+        missing = expected - search_set
+        extra = search_set - expected
+        if missing:
+            print(f"  ✗ 缺失实例: {missing}")
+        if extra:
+            print(f"  ✗ 多余实例: {extra}")
+        return 1
+
+    # 验证 RSS 只有 nitter.net
+    if rss_set == {"https://nitter.net"}:
+        print("  ✓ RSS 实例仅包含 nitter.net")
+    else:
+        print(f"  ✗ RSS 实例配置异常: {rss_set}")
+        return 1
+
+    print("\n" + "=" * 60)
+    print("✅ 所有验证通过！")
+    print("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_default_instances.py
+++ b/tests/test_default_instances.py
@@ -53,7 +53,7 @@ def test_schema_no_blogger_html_instances_key():
         "https://nitter.kareem.one",
     ]
     assert basic["user_html_fallback"]["default"] is False
-    assert basic["user_html_fallback"].get("invisible") is True
+    # user_html_fallback is now visible (invisible removed) for user choice
     joined = " ".join(basic["search_instances"]["default"])
     assert "poast" in joined and "kareem" in joined and "tiekoetter" in joined
     marker = schema["_search_instances_default_v17_migrated"]

--- a/tests/test_user_html_fallback.py
+++ b/tests/test_user_html_fallback.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from media_support.html_backend.service import HtmlBackendConfig, HtmlNitterService
 
 

--- a/tests/test_user_html_fallback.py
+++ b/tests/test_user_html_fallback.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Test user_html_fallback: RSS failure → HTML blogger fallback."""
+
+from __future__ import annotations
+
+import pytest
+
+from media_support.html_backend.service import HtmlBackendConfig, HtmlNitterService
+
+
+def test_user_html_fallback_disabled_by_default():
+    """Default: user_html_fallback=false, blogger_html pool empty."""
+    config = HtmlBackendConfig(
+        user_html_fallback=False,
+        search_instances=["https://a.example", "https://b.example"],
+    )
+    service = HtmlNitterService(config)
+
+    assert service.config.user_html_fallback is False
+    assert service.blogger_html.instances == []
+    assert len(service.search_pool.instances) == 2
+
+
+def test_user_html_fallback_enabled_shares_search_instances():
+    """user_html_fallback=true → blogger_html shares search_instances."""
+    config = HtmlBackendConfig(
+        user_html_fallback=True,
+        search_instances=["https://a.example", "https://b.example"],
+    )
+    service = HtmlNitterService(config)
+
+    assert service.config.user_html_fallback is True
+    assert service.blogger_html.instances == [
+        "https://a.example",
+        "https://b.example",
+    ]
+    assert service.search_pool.instances == ["https://a.example", "https://b.example"]
+
+
+def test_fetch_user_returns_empty_when_disabled():
+    """user_html_fallback=false → fetch_user returns empty immediately."""
+    config = HtmlBackendConfig(
+        user_html_fallback=False,
+        search_instances=["https://a.example"],
+    )
+    service = HtmlNitterService(config)
+
+    base, tweets = service.fetch_user("testuser", limit=5)
+    assert base == ""
+    assert tweets == []
+
+
+def test_fetch_user_attempts_pool_when_enabled():
+    """user_html_fallback=true → fetch_user uses blogger_html pool."""
+    config = HtmlBackendConfig(
+        user_html_fallback=True,
+        search_instances=["https://a.example"],
+    )
+    service = HtmlNitterService(config)
+
+    # Mock _fetch_user_once to verify it's called
+    call_count = 0
+
+    def mock_fetch(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return "https://a.example", []
+
+    service.blogger_html._fetch_user_once = mock_fetch
+
+    base, tweets = service.fetch_user("testuser", limit=5)
+    assert call_count == 1  # Pool was used
+    assert base == "https://a.example"
+
+
+def test_shared_limiter_and_session():
+    """blogger_html and search_pool share limiter and session."""
+    config = HtmlBackendConfig(
+        user_html_fallback=True,
+        search_instances=["https://a.example"],
+    )
+    service = HtmlNitterService(config)
+
+    assert service.blogger_html.limiter is service.limiter
+    assert service.blogger_html.session is service.session
+    assert service.search_pool.limiter is service.limiter
+    assert service.search_pool.session is service.session


### PR DESCRIPTION
- Remove 'invisible: true' from user_html_fallback in schema
- Update hint to clearly explain RSS→HTML fallback behavior
- Implement blogger_html pool sharing with search_instances when enabled
- Add 5 comprehensive tests for user_html_fallback feature
- Update documentation in README, advanced.md, instances-guide.md
- Default remains false to avoid search resource starvation
- When enabled, RSS failures fall back to HTML /username path
- Tests verify: disabled by default, instance sharing, early return, pool usage

All 315 tests pass.